### PR TITLE
Fix crash on double-clicking on second part of \t character in lines ending with \t

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -3332,6 +3332,13 @@ TextEditor::Coordinate TextEditor::Document::findWordStart(Coordinate from) cons
 	} else {
 		auto& line = at(from.line);
 		auto index = getIndex(from);
+		if (index >= line.size()) {
+            if (index > 0) {
+                index--;
+            } else {
+                return from;
+            }
+        }
 		auto firstCharacter = line[index].codepoint;
 
 		if (CodePoint::isWhiteSpace(firstCharacter)) {


### PR DESCRIPTION
This fixes a crash that happens when double-clicking on second half of \t character in lines where \t is the last character (including where \t is the only character)