### PR TITLE
Some changes from Dear ImGui Bundle

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -170,6 +170,7 @@ void TextEditor::render(const char* title, const ImVec2& size, bool border) {
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
 	ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::ColorConvertU32ToFloat4(palette.get(Color::background)));
 	ImGui::BeginChild(title, size, border, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoNavInputs);
+	lastRenderOrigin = ImGui::GetCursorScreenPos();
 
 	// handle keyboard and mouse inputs
 	handleKeyboardInputs();
@@ -1303,6 +1304,30 @@ void TextEditor::getCursor(int& startLine, int& startColumn, int& endLine, int& 
 std::string TextEditor::getCursorText(size_t cursor) const {
 	cursor = std::min(cursor, cursors.size() - 1);
 	return document.getSectionText(cursors[cursor].getSelectionStart(), cursors[cursor].getSelectionEnd());
+}
+
+
+//
+//	TextEditor::GetWordAtScreenPos
+//
+
+std::string TextEditor::GetWordAtScreenPos(const ImVec2& screenPos) const {
+	// Convert screen position to local coordinates using the origin saved during last Render()
+	auto local = screenPos - lastRenderOrigin;
+
+	// Convert to text coordinates using the same logic as handleMouseInteractions()
+	Coordinate glyphCoordinate;
+	Coordinate cursorCoordinate;
+	document.normalizeCoordinate(
+		local.y / glyphSize.y,
+		(local.x - textOffset) / glyphSize.x,
+		glyphCoordinate,
+		cursorCoordinate);
+
+	// Find word boundaries and extract text
+	auto start = document.findWordStart(glyphCoordinate);
+	auto end = document.findWordEnd(glyphCoordinate);
+	return document.getSectionText(start, end);
 }
 
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2355,11 +2355,11 @@ TextEditor::Palette TextEditor::defaultPalette = TextEditor::GetDarkPalette();
 //
 
 TextEditor::Coordinate TextEditor::Cursor::adjustCoordinateForInsert(Coordinate coordinate, Coordinate insertStart, Coordinate insertEnd) {
-	coordinate.line += insertEnd.line - insertStart.line;
-
-	if (end.line == coordinate.line) {
+	if (insertStart.line == coordinate.line) {
 		coordinate.column += insertEnd.column - insertStart.column;
 	}
+
+	coordinate.line += insertEnd.line - insertStart.line;
 
 	return coordinate;
 }

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -6245,7 +6245,7 @@ bool TextEditor::CodePoint::isWhiteSpace(ImWchar codepoint) {
 
 bool TextEditor::CodePoint::isWord(ImWchar codepoint) {
 	if (codepoint < 0x7f) {
-		return (static_cast<unsigned>((codepoint | 32) - 'a') < 26) || (static_cast<unsigned>(codepoint - '0') < 10);
+		return (static_cast<unsigned>((codepoint | 32) - 'a') < 26) || (static_cast<unsigned>(codepoint - '0') < 10) || codepoint == '_';
 
 #if defined(IMGUI_USE_WCHAR32)
 	} else if (codepoint >= 0x10000) {

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -148,6 +148,9 @@ public:
 	inline void GetMainCursor(int& line, int& column) const { return getCursor(line, column, cursors.getMainIndex()); }
 	inline void GetCurrentCursor(int& line, int& column) const { return getCursor(line, column, cursors.getCurrentIndex()); }
 
+	// get the word at a screen position (e.g. from ImGui::GetMousePos()) - uses the origin saved during the last Render() call
+	std::string GetWordAtScreenPos(const ImVec2& screenPos) const;
+
 	// scrolling support
 	enum class Scroll {
 		alignTop,
@@ -1281,6 +1284,7 @@ protected:
 	ImFont* font;
 	float fontSize;
 	ImVec2 glyphSize;
+	ImVec2 lastRenderOrigin;
 	float lineNumberLeftOffset;
 	float lineNumberRightOffset;
 	float decorationOffset;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -148,6 +148,15 @@ public:
 	inline void GetMainCursor(int& line, int& column) const { return getCursor(line, column, cursors.getMainIndex()); }
 	inline void GetCurrentCursor(int& line, int& column) const { return getCursor(line, column, cursors.getCurrentIndex()); }
 
+	// Alternative API for cursor and selection position using lightweight out struct (line and column are zero-based)
+	struct CursorPosition { int line = 0; int column = 0; };
+	struct CursorSelection { CursorPosition start; CursorPosition end; };
+	inline CursorPosition GetMainCursorPosition() const { CursorPosition p; getCursor(p.line, p.column, cursors.getMainIndex()); return p; }
+	inline CursorPosition GetCurrentCursorPosition() const { CursorPosition p; getCursor(p.line, p.column, cursors.getCurrentIndex()); return p; }
+	inline CursorPosition GetCursorPosition(size_t cursor) const { CursorPosition p; getCursor(p.line, p.column, cursor); return p; }
+	inline CursorSelection GetCursorSelection(size_t cursor) const { CursorSelection s; getCursor(s.start.line, s.start.column, s.end.line, s.end.column, cursor); return s; }
+	inline CursorSelection GetMainCursorSelection() const { return GetCursorSelection(cursors.getMainIndex()); }
+
 	// get the word at a screen position (e.g. from ImGui::GetMousePos()) - uses the origin saved during the last Render() call
 	std::string GetWordAtScreenPos(const ImVec2& screenPos) const;
 


### PR DESCRIPTION
Hi,

Here are some simple fixes and API changes from Dear ImGui Bundle. You may either merge this PR or cherry pick the commits you want to use & exclude the others.

- e5e9f5640ee3fd2b412d9637d47af78ce11dcfd9: Fix an issue with multicursor edition
<img width="191" height="57" alt="image" src="https://github.com/user-attachments/assets/e05ef650-bdff-4d81-ae17-31fe7e73cf98" />

(when editing with multiple cursor, each subsequent cursor was moved by 1 char, which was incorrect)

- b37142d739aae6eba9a62fc2ce27474837cb5b57: add  GetWordAtScreenPos() - get the word at a screen position (e.g. from ImGui::GetMousePos())

This is used in [Dear ImGui Explorer](https://pthom.github.io/imgui_explorer/)
<img width="700" height="214" alt="image" src="https://github.com/user-attachments/assets/b9f21c31-d0fb-447d-bc1e-042082ffd58d" />

- 78dfcb5219adde60adb4438991c3da7a8b16c6ee: consider "_" as part of words

- 39f72d8909d91daa82b50f49f7f37b9492a11560: add API for cursor and selection position that is easier to use and compatible with Python bindings

