### PR TITLE
Do not show a caret / cursor in read-only mode

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -455,6 +455,10 @@ void TextEditor::renderText() {
 //
 
 void TextEditor::renderCursors() {
+	// Read-only: no caret
+	if (config.readOnly)
+		return;
+
 	// update cursor animation timer
 	cursorAnimationTimer = std::fmod(cursorAnimationTimer + ImGui::GetIO().DeltaTime, 1.0f);
 


### PR DESCRIPTION
This is a small patch that prevents the cursor from blinking in read-only mode. Selecting text remains possible.

I use this when integrated in imgui bundle, since your editor is used as the base viewer for code snippets in the markdown viewer: showing a blinking cursor would seem strange in this situation. 

This reproduces the standard behavior of code viewers  in web pages (see for example the viewer at https://jupyterbook.org/stable/get-started/create-content/ )
