### PR TITLE
fix: use absolute screen coords for text clip rect

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -136,8 +136,8 @@ void TextEditor::render(const char* title, const ImVec2& size, bool border) {
 		auto drawList = ImGui::GetWindowDrawList();
 
 		drawList->PushClipRect(
-			ImVec2(textLeftOffset, drawList->GetClipRectMin().y),
-			ImVec2(textRightOffset, drawList->GetClipRectMax().y),
+			ImVec2(cursorScreenPos.x + textLeftOffset, drawList->GetClipRectMin().y),
+			ImVec2(cursorScreenPos.x + textRightOffset, drawList->GetClipRectMax().y),
 			false);
 
 		// render parts in the text area


### PR DESCRIPTION
PushClipRect expects absolute screen coordinates, but textLeftOffset and textRightOffset are offsets relative to cursorScreenPos.

So, when the editor was displayed in a child window for which x > 0, the text could be clipped.

Example:
```cpp
    // A window to the left
    ImGui::BeginChild("left", ImVec2(300, 0), ImGuiChildFlags_ResizeX);
    ImGui::Text("Left");
    ImGui::EndChild();

    ImGui::SameLine();

    ImGui::BeginChild("Main");
    editor.Render("Editor");
    ImGui::EndChild();
```