### PR TITLE
Minimap adjust

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -698,6 +698,10 @@ void TextEditor::renderMiniMap() {
 		auto drawList = ImGui::GetWindowDrawList();
 		auto pos = ImGui::GetWindowPos() + ImVec2(miniMapOffset, 0.0f);
 
+		// map a reference column count onto the minimap width (wrapped text width when word wrap is on, otherwise a configurable column count)
+		auto referenceColumns = config.wordWrap ? config.wordWrapColumns : config.miniMapColumns;
+		auto miniMapTextWidth = referenceColumns > 0 ? config.miniMapWidth / static_cast<float>(referenceColumns) : 0.0f;
+
 		for (size_t i = firstMiniMapRow; i < lastMiniMapRow; i++) {
 			auto& row = miniMap.rows[i];
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -639,6 +639,9 @@ void TextEditor::renderFoldIndicators() {
 
 void TextEditor::renderMiniMap() {
 	if (config.showMiniMap) {
+		auto miniMapRowHeight = getMiniMapRowHeight();
+		auto miniMapTextHeight = getMiniMapTextHeight();
+
 		// reset background colors
 		for (auto& row : miniMap.rows) {
 			row.color = 0;
@@ -1361,7 +1364,7 @@ void TextEditor::handleMouseInteractions() {
 
 				} else if (overMiniMap) {
 					if (ImGui::GetCurrentWindow()->ScrollbarY) {
-						auto clickedRow = firstMiniMapRow + static_cast<size_t>(absoluteMousePos.y / miniMapRowHeight);
+						auto clickedRow = firstMiniMapRow + static_cast<size_t>(absoluteMousePos.y / getMiniMapRowHeight());
 
 						if (clickedRow < firstVisibleRow || clickedRow > lastVisibleRow) {
 							scrollToLine(visPos2DocPos(VisPos(clickedRow, 0)).line, Scroll::alignMiddle);

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -1606,8 +1606,11 @@ protected:
 	static constexpr size_t textMargin = 2;
 	static constexpr size_t cursorWidth = 1;
 
-	static constexpr float miniMapRowHeight = 3.0f; // sizes are expressed in logical pixels
-	static constexpr float miniMapTextHeight = 2.0f;
+	// minimap sizes (heights) are expressed in (integer) physical pixels: text and row heights are derived by multiplying by 2 and 3 respectively
+	static constexpr int miniMapBaseHeightInPhysicalPixels = 1;
+	static float miniMapPhysicalPixel() { float s = ImGui::GetIO().DisplayFramebufferScale.y; return s > 0.0f ? 1.0f / s : 1.0f; } // for example, a physical pixel corresponds to 0.5 logical pixels on macOS / retina screen
+	static float getMiniMapRowHeight() { return miniMapBaseHeightInPhysicalPixels * 3 * miniMapPhysicalPixel(); }
+	static float getMiniMapTextHeight() { return miniMapBaseHeightInPhysicalPixels * 2 * miniMapPhysicalPixel(); }
 	static constexpr float miniMapAlpha = 0.45f;
 	static constexpr float miniMapViewPortAlpha = 0.15f;
 	static constexpr float miniMapViewPortActiveAlpha = 0.3f;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -118,6 +118,8 @@ public:
 	inline bool IsShowMiniMapEnabled() const { return config.showMiniMap; }
 	inline void SetMiniMapWidth(float value) { config.miniMapWidth = value; }
 	inline float GetMiniMapWidth() const { return config.miniMapWidth; }
+	inline void SetMiniMapColumns(size_t value) { config.miniMapColumns = value; }
+	inline size_t GetMiniMapColumns() const { return config.miniMapColumns; }
 	inline void SetShowScrollbarMiniMapEnabled(bool value) { config.showScrollbarMiniMap = value; }
 	inline bool IsShowScrollbarMiniMapEnabled() const { return config.showScrollbarMiniMap; }
 	inline void SetShowPanScrollIndicatorEnabled(bool value) { config.showPanScrollIndicator = value; }
@@ -820,7 +822,8 @@ protected:
 		bool showTabs = true;
 		bool showLineNumbers = true;
 		bool showMiniMap = false;
-		float miniMapWidth = 120.0f;
+		float miniMapWidth = 120.0f;   // minimap panel width, in pixels
+		size_t miniMapColumns = 120;   // column count that fills the minimap width (when wordWrap is off; otherwise the wrap width is used, i.e. wordWrapColumns)
 		bool showScrollbarMiniMap = true;
 		bool showMatchingBrackets = true;
 		bool completePairedGlyphs = true;
@@ -1605,7 +1608,6 @@ protected:
 
 	static constexpr float miniMapRowHeight = 3.0f; // sizes are expressed in logical pixels
 	static constexpr float miniMapTextHeight = 2.0f;
-	static constexpr float miniMapTextWidth = 1.0f;
 	static constexpr float miniMapAlpha = 0.45f;
 	static constexpr float miniMapViewPortAlpha = 0.15f;
 	static constexpr float miniMapViewPortActiveAlpha = 0.3f;


### PR DESCRIPTION
Here are two small improvements to the minimap:

- Made the minimap display a configurable column count:  we compute the character width so that the minimap corresponds to 120 columns (by default), or to the wrap width. As a consequence, the rendering of the minimap remains consistent independently of its width.
- minimap TextHeight and RowHeight are expressed in physical pixels (and correspond to 2 and 3 physical pixels): this way the rendering is as crisp as possible (integer values), as small as possible, and consistent between windows / macOS
