### PR TITLE
Add option to dismiss autocomplete silently when there are no suggestions

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -4746,6 +4746,13 @@ bool TextEditor::Autocomplete::render(Document& document, Cursors& cursors, cons
 		cursorScreenPos.y + (currentLocation.line + 1) * glyphSize.y));
 
 	auto suggestions = state.suggestions.size();
+
+	// an empty result while typing dismisses silently; only a manual
+	// trigger earns the "no suggestions" feedback
+	if (configuration.dismissWhenEmpty && suggestions == 0 && !state.suggestionsPromise && !triggeredManually) {
+		requestDeactivation = true;
+	}
+
 	auto visibleSuggestions = (suggestions == 0) ? 1 : std::min(static_cast<size_t>(10), suggestions);
 	auto& style = ImGui::GetStyle();
 	auto height = ImGui::GetFrameHeightWithSpacing() * visibleSuggestions + style.WindowPadding.y * 2.0f;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -546,6 +546,10 @@ public:
 		// this only works when triggered manually
 		bool autoInsertSingleSuggestions = false;
 
+		// see if the popup is dismissed silently when typing produces no suggestions
+		// a manual trigger still shows the noSuggestionsLabel feedback (and this respects suggestionsPromise)
+		bool dismissWhenEmpty = false;
+
 		// delay in milliseconds between autocomplete trigger and suggestions popup
 		std::chrono::milliseconds triggerDelay{200};
 


### PR DESCRIPTION
Right now, if you keep typing and the suggestion list comes back empty, the
popup stays open showing the "No suggestions" label. That's useful when you
asked for completions on purpose (Ctrl/Cmd+Space), but while you're just
typing along it's noise that sits on top of the code.

I ran into this in [Orkige](https://github.com/orkitec/orkige)'s embedded
script editor, where completions appear as you type Lua and the empty popup
kept covering the next line of code.

This adds a `dismissWhenEmpty` flag to `AutoCompleteConfig`. When it's on and
typing produces zero suggestions, the popup closes quietly instead of showing
the label. A manual trigger still shows the "No suggestions" feedback as
before, and the async `suggestionsPromise` path is respected (the popup isn't
dismissed while suggestions are still being fetched).

Default is `false`, so existing behavior is unchanged.

Usage:

    TextEditor::AutoCompleteConfig config;
    config.callback = ...;
    config.dismissWhenEmpty = true; // don't show "No suggestions" while typing
    editor.SetAutoCompleteConfig(&config);
