### PR TITLE
Make the line number left margin configurable

### DIFF
--- a/TextEditor.h
+++ b/TextEditor.h
@@ -66,6 +66,8 @@ public:
 	inline bool IsShowTabsEnabled() const { return showTabs; }
 	inline void SetShowLineNumbersEnabled(bool value) { showLineNumbers = value; }
 	inline bool IsShowLineNumbersEnabled() const { return showLineNumbers; }
+	inline void SetLineNumberLeftMargin(int value) { leftMargin = std::max(0, value); } // margin is expressed in glyphs
+	inline int GetLineNumberLeftMargin() const { return leftMargin; }
 	inline void SetShowScrollbarMiniMapEnabled(bool value) { showScrollbarMiniMap = value; }
 	inline bool IsShowScrollbarMiniMapEnabled() const { return showScrollbarMiniMap; }
 	inline void SetShowPanScrollIndicatorEnabled(bool value) { showPanScrollIndicator = value; }
@@ -1347,7 +1349,7 @@ protected:
 	int contextMenuLine = 0;
 	int contextMenuColumn = 0;
 
-	static constexpr int leftMargin = 1; // margins are expressed in glyphs
+	int leftMargin = 1; // margins are expressed in glyphs
 	static constexpr int decorationMargin = 1;
 	static constexpr int textMargin = 2;
 	static constexpr int cursorWidth = 1;


### PR DESCRIPTION
The sidebar's left margin is currently a fixed `static constexpr int
leftMargin = 1` (in glyphs). This makes it an instance member with a
`SetLineNumberLeftMargin` / `GetLineNumberLeftMargin` accessor pair, matching
the existing inline Set*/Get* option API.

The reason: applications that draw their own annotations in front of the line
numbers (badges, markers, etc.) have no room to work with at a 1-glyph margin.
In [Orkige](https://github.com/orkitec/orkige)'s script editor we draw a
warning badge there and the glyph sat cramped against the first digit.
Being able to widen it a little gives those decorations some breathing space
without patching the source.

Default stays `1`, so the layout is unchanged unless you set it.

Usage:

    editor.SetLineNumberLeftMargin(2); // two glyphs of room before the numbers
