### PR TITLE
Fixed crash when hovering an empty line with a text hover callback

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -8314,7 +8314,8 @@ void TextEditor::TypeSetter::screenPos2DocPos(const Document& document, ImVec2 s
 			auto leftDiff = screenPos.x - static_cast<float>(leftColumn);
 			auto rightDiff = static_cast<float>(rightColumn) - screenPos.x;
 
-			glyphPos = DocPos(row.line, index - 1);
+			// when the loop above didn't run (e.g. on an empty line), there is no glyph before this position
+			glyphPos = DocPos(row.line, leftColumn == rightColumn ? index : index - 1);
 			cursorPos = DocPos(row.line, leftDiff <= rightDiff ? index - 1 : index);
 		}
 	}


### PR DESCRIPTION
TypeSetter::screenPos2DocPos could raise a segfault when the loop over the row's glyphs never ran (e.g empty line, or mouse at the very left).

The resulting (size_t)-1 reached docPos2VisPos, where line.begin() + pos.index dereferences null on an empty line.

To reproduce: use something like

```cpp
void Setup()
{
    editor.SetText("line 1\n\nline 3\n");

    editor.SetTextHoverCallback([](TextEditor::PopupData& data) {
        ImGui::Text("line %zu, column %zu", data.pos.line + 1, data.pos.index + 1);
    });

}

void Gui()
{
    ImGui::TextUnformatted("Hover the first column of line 2 (the empty line): it crashes.");
    editor.Render("##editor");
}

```