### PR TITLE
Fixed debug assertion on empty text

### DIFF
--- a/TextEditor.h
+++ b/TextEditor.h
@@ -1094,7 +1094,7 @@ protected:
 			appendLine();
 
 			// process UTF-8 and generate lines of glyphs
-			std::string_view sv(reinterpret_cast<const char*>(&*text.begin()), text.size());
+			std::string_view sv(reinterpret_cast<const char*>(text.data()), text.size());
 			auto i = sv.begin();
 			auto end = sv.end();
 


### PR DESCRIPTION
Dereferencing `text.begin()` is technically illegal if `text` is empty, although I presume it's unlikely to cause any real world issues in release builds.
In a debug MSVC build though, an assert is raised.

To reproduce: call `editor->ClearText()` which calls `editor->SetText("")` which passes an empty string, causing the assert.
On the other hand, `.data()` is a valid pointer even if `text` is empty.