### PR TITLE
Reserve two grid cells for East Asian wide glyphs (CJK)

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -23,6 +23,32 @@
 
 
 //
+//	glyph columns reserved on the monospace grid
+//
+//	East Asian wide/fullwidth codepoints (CJK, Hangul, Kana, fullwidth
+//	forms, emoji) render about two cells wide in the fonts that carry
+//	them; reserving two grid cells keeps them from overprinting their
+//	neighbours. Ranges follow Unicode East Asian Width wide/fullwidth.
+//
+
+static size_t glyphColumns(uint32_t codepoint) {
+	if ((codepoint >= 0x1100 && codepoint <= 0x115F)	// Hangul Jamo
+		|| (codepoint >= 0x2E80 && codepoint <= 0xA4CF)	// CJK radicals .. Yi
+		|| (codepoint >= 0xAC00 && codepoint <= 0xD7A3)	// Hangul syllables
+		|| (codepoint >= 0xF900 && codepoint <= 0xFAFF)	// CJK compatibility ideographs
+		|| (codepoint >= 0xFE30 && codepoint <= 0xFE4F)	// CJK compatibility forms
+		|| (codepoint >= 0xFF00 && codepoint <= 0xFF60)	// fullwidth forms
+		|| (codepoint >= 0xFFE0 && codepoint <= 0xFFE6)	// fullwidth signs
+		|| (codepoint >= 0x1F300 && codepoint <= 0x1FAFF)	// emoji
+		|| (codepoint >= 0x20000 && codepoint <= 0x3FFFD)) {	// CJK extension planes
+		return 2;
+	} else {
+		return 1;
+	}
+}
+
+
+//
 //	TextEditor::TextEditor
 //
 
@@ -533,7 +559,7 @@ void TextEditor::renderSquiggles() {
 
 				// handle regular glyphs
 				} else {
-					column++;
+					column += glyphColumns(codepoint);
 				}
 			}
 
@@ -621,7 +647,7 @@ void TextEditor::renderText() {
 					font->RenderChar(drawList, fontSize, glyphPos, palette.get(glyph.color), codepoint);
 				}
 
-				column++;
+				column += glyphColumns(codepoint);
 			}
 		}
 
@@ -7996,7 +8022,7 @@ void TextEditor::TypeSetter::wrapLine(Line& line) {
 			}
 
 			// update column count
-			columns = (codepoint == '\t') ? ((columns / tabSize) + 1) * tabSize : columns + 1;
+			columns = (codepoint == '\t') ? ((columns / tabSize) + 1) * tabSize : columns + glyphColumns(codepoint);
 
 			if (columns < wordWrapColumns) {
 				// we're not at the end of the row yet so we have to track any break options
@@ -8071,7 +8097,7 @@ void TextEditor::TypeSetter::updateLine(Line& line) {
 		line.columns = 0;
 
 		for (const auto& glyph : line) {
-			line.columns = (glyph.codepoint == '\t') ? ((line.columns / tabSize) + 1) * tabSize : line.columns + 1;
+			line.columns = (glyph.codepoint == '\t') ? ((line.columns / tabSize) + 1) * tabSize : line.columns + glyphColumns(glyph.codepoint);
 		}
 
 		// reset multiline sections
@@ -8186,7 +8212,7 @@ TextEditor::VisPos TextEditor::TypeSetter::docPos2VisPos(const Document& documen
 				visPos.column = section.indent;
 
 				for (auto glyph = start; glyph < end; glyph++) {
-					visPos.column = (glyph->codepoint == '\t') ? ((visPos.column / tabSize) + 1) * tabSize : visPos.column + 1;
+					visPos.column = (glyph->codepoint == '\t') ? ((visPos.column / tabSize) + 1) * tabSize : visPos.column + glyphColumns(glyph->codepoint);
 				}
 
 				done = true;
@@ -8201,7 +8227,7 @@ TextEditor::VisPos TextEditor::TypeSetter::docPos2VisPos(const Document& documen
 		auto end = line.begin() + pos.index;
 
 		for (auto glyph = line.begin(); glyph < end; glyph++) {
-			visPos.column = (glyph->codepoint == '\t') ? ((visPos.column / tabSize) + 1) * tabSize : visPos.column + 1;
+			visPos.column = (glyph->codepoint == '\t') ? ((visPos.column / tabSize) + 1) * tabSize : visPos.column + glyphColumns(glyph->codepoint);
 		}
 	}
 
@@ -8251,7 +8277,7 @@ TextEditor::DocPos TextEditor::TypeSetter::visPos2DocPos(const Document& documen
 
 	for (auto glyph = start; rightColumn < pos.column && glyph < end; glyph++) {
 		leftColumn = rightColumn;
-		rightColumn = (glyph->codepoint == '\t') ? ((rightColumn / tabSize) + 1) * tabSize : rightColumn + 1;
+		rightColumn = (glyph->codepoint == '\t') ? ((rightColumn / tabSize) + 1) * tabSize : rightColumn + glyphColumns(glyph->codepoint);
 		index++;
 	}
 
@@ -8334,7 +8360,7 @@ void TextEditor::TypeSetter::screenPos2DocPos(const Document& document, ImVec2 s
 
 			for (auto glyph = start; static_cast<float>(rightColumn) < screenPos.x && glyph < end; glyph++) {
 				leftColumn = rightColumn;
-				rightColumn = (glyph->codepoint == '\t') ? ((rightColumn / tabSize) + 1) * tabSize : rightColumn + 1;
+				rightColumn = (glyph->codepoint == '\t') ? ((rightColumn / tabSize) + 1) * tabSize : rightColumn + glyphColumns(glyph->codepoint);
 				index++;
 			}
 


### PR DESCRIPTION
## Problem

With a CJK fallback font merged into the atlas (the standard way to display
Chinese/Japanese/Korean comments), every wide glyph overprints its
neighbours. The layout grid advances exactly one cell per codepoint, with the
cell width measured from `#`. A CJK glyph comes from the fallback font at
roughly two cells wide, so each new glyph starts before the previous one ends
— the text becomes unreadable. (The old BalazsJako editor treated non-ASCII
as double-width; the 2024 rewrite dropped that.)

## Fix

Add a `glyphColumns()` helper keyed on the Unicode **East Asian Width
wide/fullwidth** ranges (Hangul Jamo, CJK radicals through Yi, Hangul
syllables, CJK compatibility ideographs/forms, fullwidth forms and signs,
emoji, CJK extension planes), and apply it at every column-advance site:

- `renderSquiggles()` and `renderText()` glyph walks
- the color-section builder
- `TypeSetter::wrapLine()` and `TypeSetter::updateLine()` column totals
- `TypeSetter::docPos2VisPos()` (both wrapped and unwrapped branches)
- `TypeSetter::visPos2DocPos()` and `TypeSetter::screenPos2DocPos()`

Because cursor rendering, selection boxes, bracket matching, mouse
hit-testing, and the minimap all derive from the same column model, keeping
the advance consistent in one helper fixes all of them together. Wide glyphs
still render at their natural width inside their two-cell slot (about 1.8
cells for CJK at equal font size); ambiguous-width characters stay one cell;
tabs and ASCII layout are unchanged.

## Testing

- Compiles cleanly with MSVC (`/std:c++20`, ImGui 1.92 headers).
- Used in production by [roxy-can](https://github.com/chemPolonium/roxy-can)
  (a CAN bus analysis tool whose script editor is cimCTE via the
  [dear-imgui-cte](https://crates.io/crates/dear-imgui-cte) Rust bindings),
  with Chinese comments as the primary editing language; before/after:

  | before | after |
  | --- | --- |
  | characters stacked at half-cell advance | clean two-cell advance, cursor and selection aligned |

Happy to adjust the wide-range table (e.g. if you'd rather gate it behind a
config flag or use a fuller EAW implementation).
